### PR TITLE
New page and redirect in HTML head

### DIFF
--- a/.github/workflows/static-page-deploy.yml
+++ b/.github/workflows/static-page-deploy.yml
@@ -18,6 +18,7 @@ jobs:
         username: ${{ secrets.dgf_ssh_user }}
         password: ${{ secrets.dgf_ssh_password }}
         port: 22
-        source: "*"
+        source: "static_page"
         target: "httpdocs"
+        strip_components: 1
         

--- a/static_page/index.html
+++ b/static_page/index.html
@@ -1,4 +1,4 @@
- <!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="UTF-8">
@@ -40,7 +40,7 @@
                 Disc Golf <b>Friends</b> Dortmund e.V.
             </div>
             <div id="footer-rest-top">
-                <div><a href="mailto:discgolffriends@gmail.com" target="_top">discgolffriends@gmail.com</a></div>
+                <div><a href="mailto:info@discgolffriends.de" target="_top">info@discgolffriends.de</a></div>
                 <div>0231-6071616</div>
             </div>
             <div id="footer-rest-bottom">

--- a/static_page/new
+++ b/static_page/new
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>Disc Golf Friends</title>
+        <link rel="icon" href="dgf-favicon.png">
+        <meta http-equiv="Refresh" content="0; url=http://vps793990.ovh.net/" />
+    </head>
+</html>


### PR DESCRIPTION
This is not the final version. We have to do it right from the hosting configuration from Netcup when we are ready for production. See #48

Fixes #3 #47 