### PR TITLE
Static placeholders in apps

### DIFF
--- a/dgf/templates/dgf/friend_list.html
+++ b/dgf/templates/dgf/friend_list.html
@@ -17,13 +17,13 @@
 {% endblock %}
 
 {% block headline %}
-    {% static_placeholder "headline" %}
+    {% static_placeholder "friends_headline" %}
 {% endblock %}
 
 {% block content %}
 
     <div id="friend-list-header-text">
-        {% static_placeholder "content" %}
+        {% static_placeholder "friends_content" %}
     </div>
 
     <div id="friends" class="contains-pdga-attribution">

--- a/dgf_cms/settings.py
+++ b/dgf_cms/settings.py
@@ -380,6 +380,7 @@ LOCALE_PATHS = [
 
 CMS_TEMPLATES = (
     ('fullwidth.html', 'Fullwidth'),
+    ('static_placeholders.html', 'Static Placeholders (ONLY FOR ADMINS)'),
 )
 
 CMS_PERMISSION = True

--- a/dgf_cms/templates/static_placeholders.html
+++ b/dgf_cms/templates/static_placeholders.html
@@ -1,6 +1,19 @@
 {% extends "base.html" %}
 {% load cms_tags i18n %}
 
+{% comment %}
+
+	This is a trick, and a good one.
+
+	There are 2 applications (`dgf` and `dgf_league`) that need some CMS at the top.
+	Since application pages can not publish CMS content here you have the following workaround.
+
+	This template contains some static placeholders that are actually used in the in other applications (right now only `dgf` and `dgf_league`).
+	Of course, you'll need to create a dummy page with this template so that you can publish the content of the static placeholders.
+	That page should be hidden for everyone that is not a CMS content editor.
+
+{% endcomment %}
+
 {% block content %}
 
 	<div>{% trans "This is the right place to change banners and text from the following pages (apps)" %}</div>
@@ -12,9 +25,5 @@
 	<h1>{% trans "LEAGUE PAGE" %}</h1>
 	{% static_placeholder "league_headline" %}
 	{% static_placeholder "league_content" %}
-
-	<h1>{% trans "DELETE ME" %}</h1>
-	{% static_placeholder "headline" %}
-	{% static_placeholder "content" %}
 
 {% endblock %}

--- a/dgf_cms/templates/static_placeholders.html
+++ b/dgf_cms/templates/static_placeholders.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% load cms_tags i18n %}
+
+{% block content %}
+
+	<div>{% trans "This is the right place to change banners and text from the following pages (apps)" %}</div>
+
+	<h1>{% trans "FRIENDS PAGE" %}</h1>
+	{% static_placeholder "friends_headline" %}
+	{% static_placeholder "friends_content" %}
+
+	<h1>{% trans "LEAGUE PAGE" %}</h1>
+	{% static_placeholder "league_headline" %}
+	{% static_placeholder "league_content" %}
+
+	<h1>{% trans "DELETE ME" %}</h1>
+	{% static_placeholder "headline" %}
+	{% static_placeholder "content" %}
+
+{% endblock %}


### PR DESCRIPTION
This is a trick, and a good one.

There are 2 applications (`dgf` and `dgf_league`) that need some CMS at the top. Since application pages can not publish CMS content I created the following workaround:
- There's a template in the `dgf_cms` application that to contain all static placeholders
- Those placeholders are the ones used in the in other applications.
- A page with this template can publish the content of the static placeholders

