### PR TITLE
fixed metrix in case tour results return more than one score per player

### DIFF
--- a/dgf/static/js/bag_tags/metrix.js
+++ b/dgf/static/js/bag_tags/metrix.js
@@ -38,7 +38,8 @@ function parseTourResults(results) {
         var userId = result["UserID"];
         var username = metrixUserIdToFriend[userId];
         if (username) {
-            parsedResults[username] = result["Total"] || result["Sum"];
+            previousResult = parsedResults[username] || 0;
+            parsedResults[username] = (result["Total"] || result["Sum"]) + previousResult;
         }
     });
     return parsedResults;


### PR DESCRIPTION
Players appear twice here: https://discgolfmetrix.com/api.php?content=result&id=2643882 although ShowTourView is 1 (true). This was never the case before. Therefore, we have to sum scores.